### PR TITLE
Run composer self-update as super user

### DIFF
--- a/install-drupal.sh
+++ b/install-drupal.sh
@@ -11,7 +11,7 @@ repo_root=$(pwd)
 source "$repo_root/.build.env"
 
 if [ "$drupal_build_composer_install" == "Y" ]; then
-  composer self-update && composer install
+  sudo composer self-update && composer install
 fi
 
 if [ "$drupal_fix_settings" == "Y" ]; then


### PR DESCRIPTION
Running a `composer self-update` as normal user will fail because normal users won't have write  access to the /usr/bin/composer (specifically /usr/bin) directory.